### PR TITLE
Set key_file in main configuration to nothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ lldap_ldaps_port: 6360
 #lldap_ldaps_certificate: "contents of certificate"
 ```
 
+If you want to bind the service to lower TCP ports (<1024), like 389 & 689,
+set below to `true`:
+
+```yaml
+lldap_bind_lower_ports: false
+```
+
 ## Dependencies
 
 None.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ lldap_ldap_user_email: "admin@example.com"
 lldap_ldap_user_pass: "REPLACE_WITH_PASSWORD"
 lldap_force_reset_admin_password: false
 lldap_key_seed: "RanD0m STR1ng"
-lldap_key_file: false
+lldap_key_file: ""
 
 # by default SQLite3 is used, but any supported backend should work
 lldap_database_url: "sqlite://{{ default_lldap_data_dir }}/users.db?mode=rwc"

--- a/README.md
+++ b/README.md
@@ -66,14 +66,15 @@ lldap_smtp_from: "LLDAP Admin <sender@example.com>"
 lldap_smtp_reply_to: "Do not reply <noreply@localhost>"
 ```
 
-If you want to expose LDAPS too, set `lldap_ldaps_enable` to `true` and provide
-certificate and private key content.
+If you want to expose LDAPS, set `lldap_ldaps_enable` to `true` and set
+`lldap_ldaps_private_key` & `lldap_ldaps_certificate` to point to their
+respective file names.
 
 ```yaml
 lldap_ldaps_enable: false
 lldap_ldaps_port: 6360
-#lldap_ldaps_private_key: "contents of private key"
-#lldap_ldaps_certificate: "contents of certificate"
+#lldap_ldaps_private_key: "path to private key"
+#lldap_ldaps_certificate: "path to server certificate"
 ```
 
 If you want to bind the service to lower TCP ports (<1024), like 389 & 689,

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ lldap_ldap_user_email: "admin@example.com"
 lldap_ldap_user_pass: "REPLACE_WITH_PASSWORD"
 lldap_force_reset_admin_password: false
 lldap_key_seed: "RanD0m STR1ng"
+lldap_key_file: false
 
 # by default SQLite3 is used, but any supported backend should work
 lldap_database_url: "sqlite://{{ default_lldap_data_dir }}/users.db?mode=rwc"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,7 +25,7 @@ lldap_ldap_user_email: '{{ default_lldap_ldap_user_email }}'
 lldap_ldap_user_pass: '{{ default_lldap_ldap_user_pass }}'
 lldap_force_reset_admin_password: '{{ default_lldap_force_reset_admin_password }}'
 lldap_key_seed: '{{ default_lldap_key_seed }}'
-lldap_key_file: false
+lldap_key_file: ""
 
 lldap_database_url: '{{ default_lldap_database_url }}'
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,3 +43,6 @@ lldap_ldaps_port: '{{ default_lldap_ldaps_port }}'
 # set when lldap_ldaps_enable is true
 # lldap_ldaps_certificate: '/path/to/file/on/host'
 # lldap_ldaps_key: '/path/to/file/on/host'
+
+# Allow binding to lower ports (<1024)
+lldap_bind_lower_ports: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,7 @@ lldap_ldap_user_email: '{{ default_lldap_ldap_user_email }}'
 lldap_ldap_user_pass: '{{ default_lldap_ldap_user_pass }}'
 lldap_force_reset_admin_password: '{{ default_lldap_force_reset_admin_password }}'
 lldap_key_seed: '{{ default_lldap_key_seed }}'
+lldap_key_file: false
 
 lldap_database_url: '{{ default_lldap_database_url }}'
 

--- a/templates/etc/lldap/lldap_config.toml.j2
+++ b/templates/etc/lldap/lldap_config.toml.j2
@@ -105,6 +105,9 @@ database_url = "{{ lldap_database_url }}"
 ## Randomly generated on first run if it doesn't exist.
 ## Env variable: LLDAP_KEY_FILE
 #key_file = "{{ lldap_data_dir }}/private_key"
+{% if lldap_key_file %}
+key_file = "{{ lldap_key_file }}
+{% endif %}
 
 ## Seed to generate the server private key, see key_file above.
 ## This can be any random string, the recommendation is that it's at least 12

--- a/templates/etc/lldap/lldap_config.toml.j2
+++ b/templates/etc/lldap/lldap_config.toml.j2
@@ -105,9 +105,7 @@ database_url = "{{ lldap_database_url }}"
 ## Randomly generated on first run if it doesn't exist.
 ## Env variable: LLDAP_KEY_FILE
 #key_file = "{{ lldap_data_dir }}/private_key"
-{% if lldap_key_file %}
-key_file = "{{ lldap_key_file }}
-{% endif %}
+key_file = "{{ lldap_key_file }}"
 
 ## Seed to generate the server private key, see key_file above.
 ## This can be any random string, the recommendation is that it's at least 12

--- a/templates/lib/systemd/lldap.service.j2
+++ b/templates/lib/systemd/lldap.service.j2
@@ -14,6 +14,8 @@ ProtectHome=true
 ProtectSystem=full
 WorkingDirectory={{ lldap_conf | dirname }}
 ReadWriteDirectories={{ lldap_data_dir }}
-
+{% if lldap_bind_lower_ports %}
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+{% endif %}
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This will silence a false positive warning when setting `key_file` under the LDAPS configuration section.